### PR TITLE
chore: Remove hugrenv from the PATH on windows to avoid compiler conflicts

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -125,11 +125,12 @@ jobs:
         #
         # For now we just remove the bundled clang from the path.
         if: ${{ startsWith(matrix.os, 'windows-') }}
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          cleaned="$(printf '%s' "$PATH" | tr ';' '\n' | grep -vi '^C:\\hugrverse\\bin$' | paste -sd ';' -)"
-          echo "PATH=$cleaned" >> "$GITHUB_ENV"
+          $hugrBin = 'C:\hugrverse\bin'
+          $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $hugrBin) }
+          $env:PATH = ($parts -join ';')
+          "PATH=$($env:PATH)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # --------------------------------
       # Build selene-sim wheel

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -128,10 +128,9 @@ jobs:
         shell: pwsh
         run: |
           $hugrBin = 'C:\hugrverse\bin'
-          $hugrBinNorm = $hugrBin.TrimEnd('\\')
-          $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_.TrimEnd('\\') -ne $hugrBinNorm) }
+          $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $hugrBin) }
           $env:PATH = ($parts -join ';')
-          "PATH=$($env:PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PATH=$($env:PATH)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # --------------------------------
       # Build selene-sim wheel
@@ -157,9 +156,9 @@ jobs:
           path: |
             /tmp/ci-cache/selene
             target/
-          key: selene-sim--build-env--cache--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}
+          key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}-cache
           restore-keys: |
-            selene-sim--build-env--cache--${{ matrix.os }}--
+            selene-sim--build-env--${{ matrix.os }}--
 
       # Perform the selene-sim build
       - name: Build selene-sim wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: wheelhouse/selene_core-*.whl
-          key: selene-core-wheel-${{ hashFiles('selene-core/**') }}
+          key: selene-core-wheel-${{ hashFiles('selene-core/**') }}-cache
 
       ##################################################################
       #
@@ -155,7 +155,7 @@ jobs:
           path: |
             /tmp/ci-cache/selene
             target/
-          key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}
+          key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}-cache
           restore-keys: |
             selene-sim--build-env--${{ matrix.os }}--
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -128,9 +128,10 @@ jobs:
         shell: pwsh
         run: |
           $hugrBin = 'C:\hugrverse\bin'
-          $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $hugrBin) }
+          $hugrBinNorm = $hugrBin.TrimEnd('\\')
+          $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_.TrimEnd('\\') -ne $hugrBinNorm) }
           $env:PATH = ($parts -join ';')
-          "PATH=$($env:PATH)" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "PATH=$($env:PATH)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # --------------------------------
       # Build selene-sim wheel
@@ -156,9 +157,9 @@ jobs:
           path: |
             /tmp/ci-cache/selene
             target/
-          key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}-cache
+          key: selene-sim--build-env--cache--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            selene-sim--build-env--${{ matrix.os }}--
+            selene-sim--build-env--cache--${{ matrix.os }}--
 
       # Perform the selene-sim build
       - name: Build selene-sim wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -115,6 +115,22 @@ jobs:
         with:
           packages: "llvm"
 
+      - name: Remove hugrenv clang from PATH on Windows
+        # We add hugrenv to provide llvm tools bundled with selene.
+        # However, on Windows, this has the side effect of adding clang
+        # into the build environment in which e.g. stim is built, instead
+        # of the default compiler, and the build fails.
+        #
+        # TODO: investigate why that build fails.
+        #
+        # For now we just remove the bundled clang from the path.
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cleaned="$(printf '%s' "$PATH" | tr ';' '\n' | grep -vi '^C:\\hugrverse\\bin$' | paste -sd ';' -)"
+          echo "PATH=$cleaned" >> "$GITHUB_ENV"
+
       # --------------------------------
       # Build selene-sim wheel
       # --------------------------------


### PR DESCRIPTION
Fixes a build bug found when building a new release of selene-sim.

Assumed chain of events:
- We added hugrenv in order to provide llvm tools for debug support into the bundled selene wheel
- CI passed, it was merged.
- When release-please ran CI tests, builds failed complaining about C:\hugrverse\bin\clang++.exe when building the _Stim_ plugin.
  - Building the stim plugin with the bundled hugrenv's clang was not the intended behaviour
  - I suspect that hugrenv automatically adding C:\hugrverse\bin to $PATH is overwriting the default compiler.
  - The likely reason this didn't happen in the initial PR is that the cargo lockfile was unchanged, so it was a cache hit, and no stim rebuild was needed. When release-please bumped versions, the cache invalidated and a full rebuild happened, hitting this fault.

To fix this, I remove C:\hugrverse\bin from the PATH after installing hugrenv. I also manually invalidate the cache keys (by adding a '-cache' suffix) to force a clean build in this PR's CI.