### PR TITLE
chore: Remove hugrenv from the PATH on windows to avoid compiler conflicts (revisted)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: wheelhouse/selene_core-*.whl
-          key: selene-core-wheel-${{ hashFiles('selene-core/**') }}-cache
+          key: selene-core-wheel-cache-${{ hashFiles('selene-core/**') }}
 
       ##################################################################
       #
@@ -156,9 +156,9 @@ jobs:
           path: |
             /tmp/ci-cache/selene
             target/
-          key: selene-sim--build-env--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}-cache
+          key: selene-sim--build-env--cache--${{ matrix.os }}--${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            selene-sim--build-env--${{ matrix.os }}--
+            selene-sim--build-env--cache--${{ matrix.os }}--
 
       # Perform the selene-sim build
       - name: Build selene-sim wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,8 @@ before-test = [
 [tool.cibuildwheel.windows.environment]
 PATH = "$PATH:$HOME/.cargo/bin"
 CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu"
+CC = "C:/mingw64/bin/gcc.exe"
+CXX = "C:/mingw64/bin/g++.exe"
 [tool.cibuildwheel.windows]
 before-all = [
     'curl -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y',


### PR DESCRIPTION
#215 did not have the intended impact.

This is another attempt at correcting the windows build environment in the presence of hugrenv.