### PR TITLE
feat: resolve confusing llvmlite version resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,6 @@ cache-keys = [
   { file = "selene-core/rust/**/*.rs" },
 ]
 
-# We maintain support for macos x86-64, but some deps have dropped support.
-# Where possible we can just pin them to specific older (but known to work)
-# versions for macos x86-64 without constraining other platforms. This, however,
-# encourages UV to pin all platforms to the same version, which isn't what we want.
-# As such, we use environments to force that split.
-constraint-dependencies = [
-  "llvmlite>0.45.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
-]
-
 [tool.ruff]
 # exclude any external code (e.g. stim) fetched in the build process
 extend-exclude = ["target"]

--- a/selene-core/pyproject.toml
+++ b/selene-core/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   # required for inspecting LLVM files to find defined and declared symbols
   # note: llvmlite 0.45.1 is the last version to support x86_64 macOS.
   "llvmlite==0.45.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-  "llvmlite~=0.45; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+  "llvmlite>0.45.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "networkx>=2.6,<4",
   "pydantic~=2.12",
   "pydot>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,6 @@ members = [
     "selene-core",
     "selene-sim",
 ]
-constraints = [{ name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">0.45.1" }]
 
 [[package]]
 name = "annotated-types"

--- a/uv.lock
+++ b/uv.lock
@@ -1466,7 +1466,7 @@ dev = [
 requires-dist = [
     { name = "hugr", specifier = ">=0.13.0" },
     { name = "lief", specifier = "~=0.17" },
-    { name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = "~=0.45" },
+    { name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">0.45.1" },
     { name = "llvmlite", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==0.45.1" },
     { name = "networkx", specifier = ">=2.6,<4" },
     { name = "pydantic", specifier = "~=2.12" },


### PR DESCRIPTION
Removes overlap between llvmlite on macos x86-64 (0.45.1 was the last to support it) and other platforms.

History:
Originally we had macos x86-64 fixed to 0.45.1 and other platforms permitting >=, but this confused UV and made it choose 0.45.1 for all platforms.

In #204 we moved to providing UV with `constraint-dependencies`, allowing the uv.lock to recognise that different platforms require different versions. However, when dependant repositories use the version of selene-core with this change (0.3.1), they found their UV also wanted to use the common denominator.

In this PR, we use non-overlapping versions for macos x86-64 and other platforms, forcing UV to acknowledge the split without the need of `constraint-dependencies` which, in retrospect, only worked in the local workspace environment.